### PR TITLE
[refactor] API クライアントを一元化

### DIFF
--- a/frontend/src/api/addresses.ts
+++ b/frontend/src/api/addresses.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import client from '@/lib/apiClient'
 
 export type AddressPayload = {
   name: string
@@ -11,11 +11,6 @@ export type AddressPayload = {
 }
 
 export type Address = AddressPayload & { id: number }
-
-const client = axios.create({
-  baseURL: 'http://localhost:8080/api',
-  withCredentials: true,
-})
 
 export const fetchAddresses = async () => {
   const res = await client.get<Address[]>('/addresses')

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,9 +1,4 @@
-import axios from 'axios'
-
-const client = axios.create({
-  baseURL: 'http://localhost:8080/api',
-  withCredentials: true,
-})
+import client from '@/lib/apiClient'
 
 export type DashboardStats = {
   productCount: number

--- a/frontend/src/api/cart.ts
+++ b/frontend/src/api/cart.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import client from '@/lib/apiClient'
 
 export type CartItem = {
   id: number
@@ -14,11 +14,6 @@ export type CartItemPayload = {
   productId: number
   quantity: number
 }
-
-const client = axios.create({
-  baseURL: 'http://localhost:8080/api',
-  withCredentials: true,
-})
 
 export const fetchCart = async (): Promise<CartItem[]> => {
   const res = await client.get<CartItem[]>('/cart')

--- a/frontend/src/api/orders.ts
+++ b/frontend/src/api/orders.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import client from '@/lib/apiClient'
 
 export type OrderItem = {
   id: number
@@ -26,11 +26,6 @@ export type Order = {
 export type OrderRequest = {
   addressId: number
 }
-
-const client = axios.create({
-  baseURL: 'http://localhost:8080/api',
-  withCredentials: true,
-})
 
 export const createOrder = async (payload: OrderRequest): Promise<Order> => {
   const res = await client.post<Order>('/orders', payload)

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -1,9 +1,4 @@
-import axios from 'axios'
-
-const api = axios.create({
-  baseURL: 'http://localhost:8080/api', //Spring Boot APIのベースURL
-  withCredentials: true, // Cookieを含める
-})
+import api from '@/lib/apiClient'
 
 export interface Product {
   id?: number

--- a/frontend/src/components/HeaderComponent.vue
+++ b/frontend/src/components/HeaderComponent.vue
@@ -70,15 +70,10 @@
 import { useAuthStore } from '@/stores/auth'
 import { useCartStore } from '@/stores/cart'
 import { useRouter } from 'vue-router'
-import axios from 'axios'
+import client from '@/lib/apiClient'
 import { computed, onMounted } from 'vue'
 
 const router = useRouter()
-
-const client = axios.create({
-  baseURL: 'http://localhost:8080/api',
-  withCredentials: true,
-})
 
 const auth = useAuthStore()
 const cartStore = useCartStore()

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,8 @@
+import axios from 'axios'
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api',
+  withCredentials: true,
+})
+
+export default apiClient

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -20,9 +20,9 @@ const auth = useAuthStore()
 auth.restoreFromStorage()
 
 if (auth.isLoggedIn) {
-  import('axios').then(({ default: axios }) => {
-    axios
-      .get<{ loggedIn: boolean }>('http://localhost:8080/api/me', { withCredentials: true })
+  import('./lib/apiClient').then(({ default: apiClient }) => {
+    apiClient
+      .get<{ loggedIn: boolean }>('/me')
       .then((res) => {
         if (!res.data.loggedIn) {
           auth.clearUser()

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -42,17 +42,12 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import axios from 'axios'
+import client from '@/lib/apiClient'
 import BaseInput from '@/components/BaseInput.vue'
 import { useAuthStore } from '@/stores/auth'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
-
-const client = axios.create({
-  baseURL: 'http://localhost:8080/api',
-  withCredentials: true,
-})
 
 const email = ref('')
 const password = ref('')

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -81,15 +81,10 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import BaseInput from '@/components/BaseInput.vue'
-import axios from 'axios'
+import client from '@/lib/apiClient'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
-
-const client = axios.create({
-  baseURL: 'http://localhost:8080/api',
-  withCredentials: true,
-})
 
 const name = ref('')
 const email = ref('')


### PR DESCRIPTION
- lib/apiClient.ts: 共通 axios インスタンスを作成（環境変数 VITE_API_BASE_URL 対応）
- 全 API モジュール (products, cart, addresses, orders, admin): 個別の axios.create を削除し共通クライアントに統一
- LoginView, RegisterView, HeaderComponent: 直接の axios 使用を共通クライアントに置換
- main.ts: セッション検証も共通クライアント経由に変更
- ハードコードされた localhost:8080 を apiClient.ts の1箇所に集約